### PR TITLE
Patch - Fix bstats shading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("com.github.SkriptLang:Skript:2.10.0-pre1")
-    shadow "org.bstats:bstats-bukkit:3.0.2"
+    implementation "org.bstats:bstats-bukkit:3.0.2"
     implementation "org.joml:joml:${jomlVersion}"
 }
 
@@ -47,6 +47,7 @@ javadoc {
 
 task shadowJar(overwrite: true, type: ShadowJar) {
     archiveFileName = 'skript-particle.jar'
+    relocate("org.bstats", "com.sovdee.skriptparticles.bstats")
 }
 
 java {

--- a/src/main/java/com/sovdee/skriptparticles/SkriptParticle.java
+++ b/src/main/java/com/sovdee/skriptparticles/SkriptParticle.java
@@ -2,8 +2,8 @@ package com.sovdee.skriptparticles;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
-import ch.njol.skript.bstats.bukkit.Metrics;
 import ch.njol.skript.util.Version;
+import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;


### PR DESCRIPTION
This PR aims to fix a shading issue with the bstats that caused it to not correctly load.

Main issue fixed was the usage of `shadow` instead of `implementation`, this caused as class not found exception, in other words incorrect shading

next was usage of Skript's metrics class, this appears to not actually exist within Skript and was created by relocation of the bstats class something that likely shouldn't be used

- [x] This pr at least has been tested to run and worked perfectly fine on latest Skript release
- [x] This pr at least has been tested to run and worked perfectly fine on latest PaperMC release
